### PR TITLE
fix: patch security vulnerabilities in Go stdlib and frontend deps

### DIFF
--- a/bot/go.mod
+++ b/bot/go.mod
@@ -1,6 +1,6 @@
 module github.com/rotki/discord-captcha
 
-go 1.26
+go 1.26.1
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0

--- a/web/package.json
+++ b/web/package.json
@@ -36,5 +36,10 @@
     "typescript": "5.9.3",
     "vite": "7.3.1",
     "vue-tsc": "3.2.5"
+  },
+  "pnpm": {
+    "overrides": {
+      "immutable": ">=5.1.5"
+    }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  immutable: '>=5.1.5'
+
 importers:
 
   .:
@@ -1679,8 +1682,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  immutable@5.1.4:
-    resolution: {integrity: sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==}
+  immutable@5.1.5:
+    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -4212,7 +4215,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immutable@5.1.4:
+  immutable@5.1.5:
     optional: true
 
   import-fresh@3.3.1:
@@ -4933,7 +4936,7 @@ snapshots:
   sass@1.93.3:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.4
+      immutable: 5.1.5
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
## Summary
- Bump Go minimum version to `1.26.1` to fix 4 standard library vulnerabilities:
  - **GO-2026-4602**: `os` — FileInfo can escape from a Root
  - **GO-2026-4601**: `net/url` — Incorrect parsing of IPv6 host literals
  - **GO-2026-4600**: `crypto/x509` — Panic on malformed certificates
  - **GO-2026-4599**: `crypto/x509` — Incorrect email constraint enforcement
- Override `immutable` to `>=5.1.5` to fix prototype pollution (GHSA-wf6x-7x77-mvgw) in transitive dep via `vite > sass`

## Test plan
- [x] `govulncheck ./...` — no vulnerabilities found
- [x] `pnpm audit` — no vulnerabilities found
- [x] `make test` / `make lint` / `make vet` — all pass
- [x] `pnpm typecheck` — passes