### PR TITLE
chore: april 2026 maintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,8 @@
     "config:recommended",
     ":dependencyDashboard",
     ":dependencyDashboardApproval",
-    ":pinAllExceptPeerDependencies"
+    ":pinAllExceptPeerDependencies",
+    "helpers:pinGitHubActionDigests"
   ],
   "minimumReleaseAge": "7 days",
   "packageRules": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,11 +3,13 @@
   "extends": [
     "config:recommended",
     ":dependencyDashboard",
-    ":dependencyDashboardApproval"
+    ":dependencyDashboardApproval",
+    ":pinAllExceptPeerDependencies"
   ],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
-      "allowedVersions": "/^(22)\\./",
+      "allowedVersions": "/^(24)\\./",
       "groupName": "Node.js",
       "matchPackageNames": ["@types/node", "node"]
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,18 @@ jobs:
       contents: read
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           package_json_file: web/package.json
 
       - name: Setup node env 🏗
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -65,18 +65,18 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: bot/go.mod
           cache-dependency-path: bot/go.sum
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           working-directory: bot
 
@@ -94,17 +94,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           package_json_file: web/package.json
 
       - name: Setup node env 🏗
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -133,14 +133,14 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       - name: Build docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           push: false
           tags: rotki/discord-captcha:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,18 +23,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: bot/go.mod
           cache-dependency-path: bot/go.sum
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: go
 
@@ -43,7 +43,7 @@ jobs:
         working-directory: bot
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
 
   analyze-js:
     name: Analyze JavaScript/TypeScript
@@ -55,17 +55,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: javascript-typescript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,20 +17,21 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           package_json_file: web/package.json
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: .nvmrc
+          package-manager-cache: false
 
-      - run: npx changelogithub
+      - run: npx changelogithub@14
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # --- Build Frontend ---
 FROM node:24-alpine AS web-build
 WORKDIR /build
-COPY web/package.json web/pnpm-lock.yaml ./
+COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile
 COPY web/ .
 ARG VITE_RECAPTCHA_SITE_KEY

--- a/bot/go.mod
+++ b/bot/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/crypto v0.49.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
 )

--- a/bot/go.sum
+++ b/bot/go.sum
@@ -26,12 +26,12 @@ github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaD
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
-golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
+golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
+golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
-golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/bot/internal/bot/match.go
+++ b/bot/internal/bot/match.go
@@ -1,0 +1,49 @@
+package bot
+
+import "github.com/rotki/discord-captcha/internal/store"
+
+// MatchResult holds the outcome of invite matching.
+type MatchResult struct {
+	// Code is the invite code that was consumed, empty if none matched.
+	Code string
+	// StoreUpdates contains invites whose use count increased and need
+	// to be written back to the cache.
+	StoreUpdates map[string]store.CachedInviteData
+}
+
+// matchUsedInvite compares a snapshot of cached invites against a snapshot of
+// the current Discord API invites to determine which bot invite was consumed.
+//
+// Detection rules (evaluated per cached invite):
+//  1. Use-count increase: invite exists in both maps and api.Uses > cached.Uses,
+//     and the inviter is the bot → match.
+//  2. Disappeared single-use: invite exists in cached but NOT in api,
+//     cached.MaxUses == 1, and the inviter is the bot → match (consumed & auto-deleted).
+func matchUsedInvite(
+	cached map[string]store.CachedInviteData,
+	api map[string]store.CachedInviteData,
+	botUserID string,
+) MatchResult {
+	result := MatchResult{StoreUpdates: make(map[string]store.CachedInviteData)}
+
+	for code, cachedData := range cached {
+		apiData, inAPI := api[code]
+
+		if inAPI && apiData.Uses > cachedData.Uses {
+			result.StoreUpdates[code] = apiData
+
+			if result.Code == "" && cachedData.Inviter != nil && cachedData.Inviter.ID == botUserID {
+				result.Code = code
+			}
+			continue
+		}
+
+		if !inAPI && cachedData.MaxUses == 1 && cachedData.Inviter != nil && cachedData.Inviter.ID == botUserID {
+			if result.Code == "" {
+				result.Code = code
+			}
+		}
+	}
+
+	return result
+}

--- a/bot/internal/bot/match_test.go
+++ b/bot/internal/bot/match_test.go
@@ -1,0 +1,128 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/rotki/discord-captcha/internal/store"
+)
+
+func botUser() *store.CachedUser {
+	return &store.CachedUser{ID: "bot-1", Username: "rotki"}
+}
+
+func otherUser() *store.CachedUser {
+	return &store.CachedUser{ID: "other-1", Username: "someone"}
+}
+
+func inv(uses, maxUses int, inviter *store.CachedUser) store.CachedInviteData {
+	return store.CachedInviteData{
+		Uses:      uses,
+		MaxUses:   maxUses,
+		Inviter:   inviter,
+		ExpiresAt: "never",
+	}
+}
+
+func TestMatchUsedInvite(t *testing.T) {
+	const botID = "bot-1"
+
+	tests := []struct {
+		name             string
+		cached           map[string]store.CachedInviteData
+		api              map[string]store.CachedInviteData
+		wantCode         string
+		wantUpdateCodes  []string // codes expected in StoreUpdates
+		wantNoUpdateCode []string // codes expected NOT in StoreUpdates
+	}{
+		{
+			name:            "use count increased on bot invite",
+			cached:          map[string]store.CachedInviteData{"abc": inv(0, 5, botUser())},
+			api:             map[string]store.CachedInviteData{"abc": inv(1, 5, botUser())},
+			wantCode:        "abc",
+			wantUpdateCodes: []string{"abc"},
+		},
+		{
+			name:     "single-use bot invite disappeared",
+			cached:   map[string]store.CachedInviteData{"abc": inv(0, 1, botUser())},
+			api:      map[string]store.CachedInviteData{},
+			wantCode: "abc",
+		},
+		{
+			name:     "multi-use bot invite disappeared — no match",
+			cached:   map[string]store.CachedInviteData{"abc": inv(0, 5, botUser())},
+			api:      map[string]store.CachedInviteData{},
+			wantCode: "",
+		},
+		{
+			name:     "non-bot single-use invite disappeared — no match",
+			cached:   map[string]store.CachedInviteData{"abc": inv(0, 1, otherUser())},
+			api:      map[string]store.CachedInviteData{},
+			wantCode: "",
+		},
+		{
+			name:            "use count increased on non-bot invite — no match but update recorded",
+			cached:          map[string]store.CachedInviteData{"abc": inv(0, 5, otherUser())},
+			api:             map[string]store.CachedInviteData{"abc": inv(1, 5, otherUser())},
+			wantCode:        "",
+			wantUpdateCodes: []string{"abc"},
+		},
+		{
+			name:     "no change in use count",
+			cached:   map[string]store.CachedInviteData{"abc": inv(0, 1, botUser())},
+			api:      map[string]store.CachedInviteData{"abc": inv(0, 1, botUser())},
+			wantCode: "",
+		},
+		{
+			name:     "nil inviter disappeared — no match",
+			cached:   map[string]store.CachedInviteData{"abc": inv(0, 1, nil)},
+			api:      map[string]store.CachedInviteData{},
+			wantCode: "",
+		},
+		{
+			name:     "empty cache",
+			cached:   map[string]store.CachedInviteData{},
+			api:      map[string]store.CachedInviteData{"abc": inv(1, 5, otherUser())},
+			wantCode: "",
+		},
+		{
+			name:     "empty cache and empty api",
+			cached:   map[string]store.CachedInviteData{},
+			api:      map[string]store.CachedInviteData{},
+			wantCode: "",
+		},
+		{
+			name: "multiple invites — only consumed one matched",
+			cached: map[string]store.CachedInviteData{
+				"alive": inv(0, 1, botUser()),
+				"gone":  inv(0, 1, botUser()),
+			},
+			api: map[string]store.CachedInviteData{
+				"alive": inv(0, 1, botUser()),
+			},
+			wantCode:         "gone",
+			wantNoUpdateCode: []string{"alive", "gone"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := matchUsedInvite(tt.cached, tt.api, botID)
+
+			if result.Code != tt.wantCode {
+				t.Errorf("Code = %q, want %q", result.Code, tt.wantCode)
+			}
+
+			for _, code := range tt.wantUpdateCodes {
+				if _, ok := result.StoreUpdates[code]; !ok {
+					t.Errorf("expected %q in StoreUpdates", code)
+				}
+			}
+
+			for _, code := range tt.wantNoUpdateCode {
+				if _, ok := result.StoreUpdates[code]; ok {
+					t.Errorf("did not expect %q in StoreUpdates", code)
+				}
+			}
+		})
+	}
+}

--- a/bot/internal/bot/monitor.go
+++ b/bot/internal/bot/monitor.go
@@ -87,51 +87,42 @@ func (m *InviteMonitor) onGuildMemberAdd(s *discordgo.Session, event *discordgo.
 
 	slog.Debug("new user joined", "id", member.ID, "username", member.Username)
 
+	// Phase 1: Snapshot — read cached and live state into plain maps
+	cachedInvites := snapshotStore(m.store)
+
 	apiInvites, err := s.GuildInvites(event.GuildID)
 	if err != nil {
 		slog.Error("failed to fetch guild invites on member add", "error", err)
 		return
 	}
 
-	currentInvites := make(map[string]store.CachedInviteData)
+	currentInvites := make(map[string]store.CachedInviteData, len(apiInvites))
 	for _, invite := range apiInvites {
 		cached := toCachedInvite(invite)
 		currentInvites[cached.Code] = cached.Data
 	}
 
-	botUserID := m.getBotUserID()
-	var usedBotInviteCode string
+	// Phase 2: Match — pure function, no side effects
+	result := matchUsedInvite(cachedInvites, currentInvites, m.getBotUserID())
 
-	for code, data := range m.store.Iterator() {
-		invite, ok := currentInvites[code]
-		if !ok {
-			continue
-		}
-
-		if invite.Uses <= data.Uses {
-			continue
-		}
-
-		// Always update the store with fresh use count
-		if err := m.store.Set(store.CachedInvite{Code: code, Data: invite}); err != nil {
+	// Phase 3: Mutate — apply store updates outside any iteration
+	for code, data := range result.StoreUpdates {
+		if err := m.store.Set(store.CachedInvite{Code: code, Data: data}); err != nil {
 			slog.Error("failed to update invite", "code", code, "error", err)
 		}
-
-		if invite.Inviter != nil && invite.Inviter.ID != botUserID {
-			slog.Debug("invite used by non-bot inviter, bailing", "code", code)
-			return
-		}
-
-		usedBotInviteCode = code
 	}
 
-	if usedBotInviteCode == "" {
+	if result.Code == "" {
 		slog.Warn("could not determine which invite was used", "user", member.Username)
 		return
 	}
 
+	if err := m.store.Delete(result.Code); err != nil {
+		slog.Error("failed to delete consumed invite from cache", "code", result.Code, "error", err)
+	}
+
 	roleID := m.config.DiscordRoleID
-	slog.Debug("adding role to user", "username", member.Username, "role", roleID, "invite", usedBotInviteCode)
+	slog.Debug("adding role to user", "username", member.Username, "role", roleID, "invite", result.Code)
 
 	if err := s.GuildMemberRoleAdd(event.GuildID, member.ID, roleID); err != nil {
 		slog.Error("failed to add role", "user", member.Username, "role", roleID, "error", err)
@@ -150,12 +141,20 @@ func (m *InviteMonitor) onInviteCreate(s *discordgo.Session, event *discordgo.In
 	}
 }
 
-func (m *InviteMonitor) onInviteDelete(s *discordgo.Session, event *discordgo.InviteDelete) {
+func (m *InviteMonitor) onInviteDelete(_ *discordgo.Session, event *discordgo.InviteDelete) {
+	// Intentionally no cache deletion here. Discord fires InviteDelete before
+	// GuildMemberAdd for single-use invites, and onGuildMemberAdd needs the
+	// cached entry to detect consumed invites. Cleanup is handled by
+	// onGuildMemberAdd (after match) and the periodic Cleanup goroutine.
 	slog.Info("invite deleted", "code", event.Code)
+}
 
-	if err := m.store.Delete(event.Code); err != nil {
-		slog.Error("failed to delete invite from cache", "code", event.Code, "error", err)
+func snapshotStore(s store.InviteStore) map[string]store.CachedInviteData {
+	snap := make(map[string]store.CachedInviteData)
+	for code, data := range s.Iterator() {
+		snap[code] = data
 	}
+	return snap
 }
 
 func toCachedInvite(invite *discordgo.Invite) store.CachedInvite {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     restart: on-failure
 
   redis:
-    image: redis:7.2-alpine
+    image: redis:7.4-alpine
     restart: on-failure
 
 volumes:

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@rotki/discord-captcha-web",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -37,9 +37,8 @@
     "vite": "7.3.1",
     "vue-tsc": "3.2.5"
   },
-  "pnpm": {
-    "overrides": {
-      "immutable": ">=5.1.5"
-    }
+  "engines": {
+    "node": ">=24 <25",
+    "pnpm": ">=10 <11"
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  chokidar: '>=5.0.0'
   immutable: '>=5.1.5'
 
 importers:
@@ -1004,10 +1005,6 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -1043,10 +1040,6 @@ packages:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
@@ -1097,14 +1090,6 @@ packages:
 
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
-
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -1707,10 +1692,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
@@ -2112,6 +2093,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -2209,14 +2194,6 @@ packages:
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
-
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -3003,7 +2980,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -3518,11 +3495,6 @@ snapshots:
 
   any-promise@1.3.0: {}
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -3553,8 +3525,6 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.0: {}
-
-  binary-extensions@2.3.0: {}
 
   birpc@2.9.0: {}
 
@@ -3599,23 +3569,6 @@ snapshots:
   change-case@5.4.4: {}
 
   character-entities@2.0.2: {}
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
-    optional: true
 
   chokidar@5.0.0:
     dependencies:
@@ -4233,10 +4186,6 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
   is-builtin-module@5.0.0:
     dependencies:
       builtin-modules: 5.0.0
@@ -4771,6 +4720,9 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4:
+    optional: true
+
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
@@ -4854,13 +4806,6 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
-
-  readdirp@4.1.2:
-    optional: true
-
   readdirp@5.0.0: {}
 
   refa@0.12.1:
@@ -4935,7 +4880,7 @@ snapshots:
 
   sass@1.93.3:
     dependencies:
-      chokidar: 4.0.3
+      chokidar: 5.0.0
       immutable: 5.1.5
       source-map-js: 1.2.1
     optionalDependencies:
@@ -5008,7 +4953,7 @@ snapshots:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
-      chokidar: 3.6.0
+      chokidar: 5.0.0
       didyoumean: 1.2.2
       dlv: 1.1.3
       fast-glob: 3.3.3

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+blockExoticSubdeps: true
+minimumReleaseAge: 10080
+saveExact: true
+shellEmulator: true
+strictDepBuilds: true
+trustPolicy: no-downgrade
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+overrides:
+  chokidar: '>=5.0.0'
+  immutable: '>=5.1.5'


### PR DESCRIPTION
## Summary

- **Fix invite matching race condition**: Discord fires `InviteDelete` before `GuildMemberAdd` for single-use invites, causing role assignment to silently fail. Extracted matching logic into a pure, testable function that detects both use-count increases and disappeared single-use bot invites. Also fixes a latent RWMutex deadlock from calling `Set()` inside an `Iterator()` loop.
- **Harden pnpm**: Added `pnpm-workspace.yaml` with `trustPolicy: no-downgrade`, `blockExoticSubdeps`, `saveExact`, `strictDepBuilds`. Override chokidar to >=5 to avoid untrusted 4.0.3.
- **Update dependencies**: Bumped frontend patch/minor deps (vue, vue-router, postcss, etc.), Go indirect deps (`golang.org/x/crypto`, `golang.org/x/sys`), Redis 7.2→7.4, pnpm 10.30.3→10.33.0 with SHA512.
- **Pin GitHub Actions to SHA digests**: All actions pinned to commit SHAs and bumped to latest majors. Added `helpers:pinGitHubActionDigests` to renovate config.
- **Renovate config**: Added `:pinAllExceptPeerDependencies`, `minimumReleaseAge: 7 days`, updated Node constraint to v24.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (10 new match tests + 28 existing)
- [x] `go vet ./...` clean
- [x] `pnpm install --frozen-lockfile` valid
- [x] `pnpm build` succeeds
- [ ] Verify CI passes on this PR